### PR TITLE
Discord Alert Plugin and replacement of deprecated methods

### DIFF
--- a/mk2/launcher.py
+++ b/mk2/launcher.py
@@ -553,11 +553,13 @@ class CommandJarList(Command):
 
     def run(self):
         def err(what):
-            if reactor.running: reactor.stop()
             print("error: {}".format(what.value))
+            if reactor.running:
+                reactor.stop()
 
         def handle(listing):
-            if reactor.running: reactor.stop()
+            if reactor.running:
+                reactor.stop()
             if len(listing) == 0:
                 print("error: no server jars found!")
             else:
@@ -583,22 +585,22 @@ class CommandJarGet(Command):
             raise Mark2ParseError("missing jar type!")
 
         def err(what):
-            #reactor.stop()
             print("error: {}".format(what.value))
+            if reactor.running:
+                reactor.stop()
 
-        def handle(filename, data):
-            reactor.stop()
+        def handle(filename):
+            if reactor.running:
+                reactor.stop()
+            if filename is None:
+                print("There was an error when saving the file!")
             if os.path.exists(filename):
-                print("error: {} already exists!").format(filename)
-            else:
-                f = open(filename, 'wb')
-                f.write(data)
-                f.close()
                 print("success! saved as {}".format(filename))
 
         def start():
             d = servers.jar_get(self.value)
-            d.addCallbacks(handle, err)
+            d.addCallback(handle)
+            d.addErrback(err)
 
         reactor.callWhenRunning(start)
 

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -1,12 +1,10 @@
-import json
-from http import client
+import treq
 
 from mk2.events import EventPriority, ServerEvent, ServerStarted, ServerStopped, ServerStopping, ServerStarting
 from mk2.plugins import Plugin
 from mk2.shared import decode_if_bytes
 
 
-class WebhookBuilder:
 class WebhookObject(dict):
     def __init__(self, username):
         self.username = username
@@ -107,7 +105,4 @@ class Discord(Plugin):
 
     def send_webhook(self, data):
         """ Sends the webhook and closes the client instance """
-        _client = client.HTTPSConnection("discord.com")
-        _client.request("POST", self.webhook_url, data, self.headers)
-        _ = _client.getresponse()
-        del _client, _
+        d = treq.post(self.webhook_url, json=data.__dict__)

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -32,6 +32,12 @@ class Discord(Plugin):
     webhook_name = Plugin.Property(default="mark2")
     server_name = Plugin.Property(required=True)
 
+    # Server event toggles
+    server_started_enabled = Plugin.Property(default=True)
+    server_stopped_enabled = Plugin.Property(default=True)
+    server_starting_enabled = Plugin.Property(default=False)
+    server_stopping_enabled = Plugin.Property(default=False)
+
     stop_types = {
         0: "Terminate",
         1: "Restart",
@@ -39,11 +45,17 @@ class Discord(Plugin):
     }
 
     def setup(self):
-        self.register(self.handle_server_event,    ServerEvent, priority=EventPriority.MONITOR)
-        self.register(self.handle_server_starting, ServerStarting)
-        self.register(self.handle_server_started,  ServerStarted)
-        self.register(self.handle_server_stopping, ServerStopping)
-        self.register(self.handle_server_stopped,  ServerStopped)
+        # Register event handlers
+        self.register(self.handle_server_event, ServerEvent, priority=EventPriority.MONITOR)
+
+        if self.server_starting_enabled:
+            self.register(self.handle_server_starting, ServerStarting)
+        if self.server_started_enabled:
+            self.register(self.handle_server_started, ServerStarted)
+        if self.server_stopping_enabled:
+            self.register(self.handle_server_stopping, ServerStopping)
+        if self.server_stopped_enabled:
+            self.register(self.handle_server_stopped, ServerStopped)
 
     def handle_server_event(self, event):
         webhook = WebhookObject(self.webhook_name)

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -37,6 +37,12 @@ class Discord(Plugin):
     webhook_name = Plugin.Property(default="mark2")
     server_name = Plugin.Property(required=True)
 
+    stop_types = {
+        0: "Terminate",
+        1: "Restart",
+        2: "Hold"
+    }
+
     def setup(self):
         # Strip the address part of the url from the URL to just leave the api call
         if self.webhook_url.find("https://discord.com/") != -1:
@@ -91,7 +97,7 @@ class Discord(Plugin):
         fields = [
             {"name": decode_if_bytes(self.server_name), "value": "Server is stopping"},
             {"name": "Reason", "value": event.reason},
-            {"name": "Respawn", "value": event.respawn}
+            {"name": "Stop Type", "value": self.stop_types.get(event.respawn)}
         ]
         webhook_builder.add_embed(title, fields)
         webhook_data = webhook_builder.get_webhook_data()

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -47,15 +47,10 @@ class Discord(Plugin):
     def setup(self):
         # Register event handlers
         self.register(self.handle_server_event, ServerEvent, priority=EventPriority.MONITOR)
-
-        if self.server_starting_enabled:
-            self.register(self.handle_server_starting, ServerStarting)
-        if self.server_started_enabled:
-            self.register(self.handle_server_started, ServerStarted)
-        if self.server_stopping_enabled:
-            self.register(self.handle_server_stopping, ServerStopping)
-        if self.server_stopped_enabled:
-            self.register(self.handle_server_stopped, ServerStopped)
+        self.register(self.handle_server_starting, ServerStarting)
+        self.register(self.handle_server_started, ServerStarted)
+        self.register(self.handle_server_stopping, ServerStopping)
+        self.register(self.handle_server_stopped, ServerStopped)
 
     def handle_server_event(self, event):
         webhook = WebhookObject(self.webhook_name)
@@ -69,48 +64,52 @@ class Discord(Plugin):
         self.send_webhook(webhook)
     
     def handle_server_starting(self, event):
-        webhook = WebhookObject(self.webhook_name)
-        title = "Server Starting Event"
-        fields = []
-        fields = [
-            {"name": decode_if_bytes(self.server_name), "value": "Server is starting"},
-            {"name": "PID", "value": event.pid},
-        ]
-        webhook.add_embed(title, fields)
+        if self.server_starting_enabled:
+            webhook = WebhookObject(self.webhook_name)
+            title = "Server Starting Event"
+            fields = []
+            fields = [
+                {"name": decode_if_bytes(self.server_name), "value": "Server is starting"},
+                {"name": "PID", "value": event.pid},
+            ]
+            webhook.add_embed(title, fields)
 
-        self.send_webhook(webhook)
+            self.send_webhook(webhook)
 
     def handle_server_started(self, event):
-        webhook = WebhookObject(self.webhook_name)
-        title = "Server Started Event"
-        fields = [
-            {"name": decode_if_bytes(self.server_name), "value": "Server Started"}
-        ]
-        webhook.add_embed(title, fields)
+        if self.server_started_enabled:
+            webhook = WebhookObject(self.webhook_name)
+            title = "Server Started Event"
+            fields = [
+                {"name": decode_if_bytes(self.server_name), "value": "Server Started"}
+            ]
+            webhook.add_embed(title, fields)
 
-        self.send_webhook(webhook)
+            self.send_webhook(webhook)
 
     def handle_server_stopping(self, event):
-        webhook = WebhookObject(self.webhook_name)
-        title = "Server Stopping Event"
-        fields = [
-            {"name": decode_if_bytes(self.server_name), "value": "Server is stopping"},
-            {"name": "Reason", "value": event.reason},
-            {"name": "Stop Type", "value": self.stop_types.get(event.respawn)}
-        ]
-        webhook.add_embed(title, fields)
+        if self.server_stopping_enabled:
+            webhook = WebhookObject(self.webhook_name)
+            title = "Server Stopping Event"
+            fields = [
+                {"name": decode_if_bytes(self.server_name), "value": "Server is stopping"},
+                {"name": "Reason", "value": event.reason},
+                {"name": "Stop Type", "value": self.stop_types.get(event.respawn)}
+            ]
+            webhook.add_embed(title, fields)
 
-        self.send_webhook(webhook)
+            self.send_webhook(webhook)
     
     def handle_server_stopped(self, event):
-        webhook = WebhookObject(self.webhook_name)
-        title = "Server Stopped Event"
-        fields = [
-            {"name": decode_if_bytes(self.server_name), "value": "Server Stopped"}
-        ]
-        webhook.add_embed(title, fields)
+        if self.server_stopped_enabled:
+            webhook = WebhookObject(self.webhook_name)
+            title = "Server Stopped Event"
+            fields = [
+                {"name": decode_if_bytes(self.server_name), "value": "Server Stopped"}
+            ]
+            webhook.add_embed(title, fields)
 
-        self.send_webhook(webhook)
+            self.send_webhook(webhook)
 
     def send_webhook(self, data):
         d = treq.post(self.webhook_url, json=data.__dict__)

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -6,6 +6,7 @@ from mk2.shared import decode_if_bytes
 
 
 class WebhookObject(dict):
+    """ Custom dict object that represents a discord webhook object """
     def __init__(self, username):
         self.username = username
         self.content = ""
@@ -38,10 +39,6 @@ class Discord(Plugin):
     }
 
     def setup(self):
-        # Strip the address part of the url from the URL to just leave the api call
-        # if self.webhook_url.find("https://discord.com/") != -1:
-        #     self.webhook_url = self.webhook_url.replace("https://discord.com/", "/")
-
         self.register(self.handle_server_event,    ServerEvent, priority=EventPriority.MONITOR)
         self.register(self.handle_server_starting, ServerStarting)
         self.register(self.handle_server_started,  ServerStarted)
@@ -104,5 +101,4 @@ class Discord(Plugin):
         self.send_webhook(webhook)
 
     def send_webhook(self, data):
-        """ Sends the webhook and closes the client instance """
         d = treq.post(self.webhook_url, json=data.__dict__)

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -1,0 +1,117 @@
+import json
+from http import client
+
+from mk2.events import EventPriority, ServerEvent, ServerStarted, ServerStopped, ServerStopping, ServerStarting
+from mk2.plugins import Plugin
+from mk2.shared import decode_if_bytes
+
+
+class WebhookBuilder:
+    def __init__(self, username):
+        self.webhook = {}
+        self.webhook["username"] = username
+        self.webhook["content"] = ""
+        self.webhook["embeds"] = self.embeds = []
+    
+    def set_content(self, content):
+        self.webhook["content"] = content
+    
+    def add_embed(self, title, fields=[]):
+        """ Creates an embed object with the specified title and optional list of fields"""
+        self.embeds.append({"title": title, "fields": fields})
+    
+    def add_embed_field(self, title, name, value, inline=False):
+        """ Adds a field to the embed matching the title given """
+        for embed in self.webhook["embeds"]:
+            if embed["title"] == title:
+                embed["fields"].append({"name": name, "value": value, "inline": inline})
+                break
+    
+    def get_webhook_data(self):
+        return json.dumps(self.webhook)
+    
+
+
+class Discord(Plugin):
+    webhook_url = Plugin.Property(required=True)
+    webhook_name = Plugin.Property(default="mark2")
+    server_name = Plugin.Property(required=True)
+
+    def setup(self):
+        # Strip the address part of the url from the URL to just leave the api call
+        if self.webhook_url.find("https://discord.com/") != -1:
+            self.webhook_url = self.webhook_url.replace("https://discord.com/", "/")
+        self.headers = {'Content-type': 'application/json'}
+        
+        self.register(self.handle_server_event,    ServerEvent, priority=EventPriority.MONITOR)
+        self.register(self.handle_server_starting, ServerStarting)
+        self.register(self.handle_server_started,  ServerStarted)
+        self.register(self.handle_server_stopping, ServerStopping)
+        self.register(self.handle_server_stopped,  ServerStopped)
+
+    def handle_server_event(self, event):
+        webhook_builder = WebhookBuilder(self.webhook_name)
+        title = "Server event from: {}".format(self.server_name)
+        fields = [
+            {"name": "Cause", "value": event.cause},
+            {"name": "Data", "value": event.data}
+        ]
+        webhook_builder.add_embed(title, fields)
+        webhook_data = webhook_builder.get_webhook_data()
+
+        self.send_webhook(webhook_data)
+    
+    def handle_server_starting(self, event):
+        webhook_builder = WebhookBuilder(self.webhook_name)
+        title = "Server Starting Event"
+        fields = []
+        fields = [
+            {"name": decode_if_bytes(self.server_name), "value": "Server is starting"},
+            {"name": "PID", "value": event.pid},
+        ]
+        webhook_builder.add_embed(title, fields)
+        webhook_data = webhook_builder.get_webhook_data()
+
+        self.send_webhook(webhook_data)
+
+    def handle_server_started(self, event):
+        webhook_builder = WebhookBuilder(self.webhook_name)
+        title = "Server Started Event"
+        fields = [
+            {"name": decode_if_bytes(self.server_name), "value": "Server Started"}
+        ]
+        webhook_builder.add_embed(title, fields)
+        webhook_data = webhook_builder.get_webhook_data()
+
+        self.send_webhook(webhook_data)
+
+    def handle_server_stopping(self, event):
+        webhook_builder = WebhookBuilder(self.webhook_name)
+        title = "Server Stopping Event"
+        fields = [
+            {"name": decode_if_bytes(self.server_name), "value": "Server is stopping!"},
+            {"name": "Reason", "value": event.reason},
+            {"name": "Respawn", "value": event.respawn}
+        ]
+        webhook_builder.add_embed(title, fields)
+        webhook_data = webhook_builder.get_webhook_data()
+
+        self.send_webhook(webhook_data)
+    
+    def handle_server_stopped(self, event):
+        webhook_builder = WebhookBuilder(self.webhook_name)
+        title = "Server Stopped Event"
+        fields = [
+            {"name": decode_if_bytes(self.server_name), "value": "Server Stopped"}
+        ]
+        webhook_builder.add_embed(title, fields)
+        webhook_data = webhook_builder.get_webhook_data()
+
+        self.send_webhook(webhook_data)
+
+    def send_webhook(self, data):
+        """ Sends the webhook and closes the client instance """
+        _client = client.HTTPSConnection("discord.com")
+        _client.request("POST", self.webhook_url, data, self.headers)
+        _ = _client.getresponse()
+        del _client, _

--- a/mk2/plugins/discord.py
+++ b/mk2/plugins/discord.py
@@ -42,7 +42,7 @@ class Discord(Plugin):
         if self.webhook_url.find("https://discord.com/") != -1:
             self.webhook_url = self.webhook_url.replace("https://discord.com/", "/")
         self.headers = {'Content-type': 'application/json'}
-        
+
         self.register(self.handle_server_event,    ServerEvent, priority=EventPriority.MONITOR)
         self.register(self.handle_server_starting, ServerStarting)
         self.register(self.handle_server_started,  ServerStarted)
@@ -89,7 +89,7 @@ class Discord(Plugin):
         webhook_builder = WebhookBuilder(self.webhook_name)
         title = "Server Stopping Event"
         fields = [
-            {"name": decode_if_bytes(self.server_name), "value": "Server is stopping!"},
+            {"name": decode_if_bytes(self.server_name), "value": "Server is stopping"},
             {"name": "Reason", "value": event.reason},
             {"name": "Respawn", "value": event.respawn}
         ]

--- a/mk2/plugins/mcbouncer.py
+++ b/mk2/plugins/mcbouncer.py
@@ -2,7 +2,8 @@ from twisted.python import log
 import urllib
 import json
 
-from twisted.web.client import HTTPClientFactory, getPage
+from twisted.web.client import HTTPClientFactory
+import treq
 HTTPClientFactory.noisy = False
 
 from mk2.plugins import Plugin
@@ -23,9 +24,9 @@ class BouncerAPI:
             args = [urllib.quote(a.encode('utf8'), "") for a in args]
             callback = kwargs.get('callback', None)
             addr = '/'.join([self.api_base, method, self.api_key] + args)
-            deferred = getPage(addr)
+            deferred = treq.get(addr)
             if callback:
-                deferred.addCallback(lambda d: callback(json.loads(str(d))))
+                deferred.addCallback(lambda d: callback(json.loads(str(d.text()))))
                 deferred.addErrback(self.errback)
         return inner
 

--- a/mk2/plugins/push.py
+++ b/mk2/plugins/push.py
@@ -4,7 +4,7 @@ from mk2.events import ServerEvent, EventPriority
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.mail import smtp, relaymanager
-from twisted.web.client import getPage
+import treq
 
 from io import StringIO
 from email.mime.text import MIMEText
@@ -65,12 +65,12 @@ class HTTPEndpoint(Endpoint):
     
     def push(self, event):
         self.setup(event)
-        
-        defer = getPage(self.endpoint,
-                        method=self.method,
-                        postdata=urlencode(self.postdata),
-                        headers={"Content-type": "application/x-www-form-urlencoded"})
-        
+
+        defer = treq.request(self.method, 
+                             self.endpoint, 
+                             headers={"Content-type": "application/x-www-form-urlencoded"}, 
+                             data=urlencode(self.postdata))
+
         self.wait(defer)
 
 

--- a/mk2/plugins/rss.py
+++ b/mk2/plugins/rss.py
@@ -1,6 +1,7 @@
 import feedparser
 import re
 import treq
+from twisted.internet import defer
 
 from mk2.plugins import Plugin
 
@@ -41,8 +42,10 @@ class RSS(Plugin):
         d = treq.get(self.url)
         d.addCallback(self.update_feeds)
     
+    @defer.inlineCallbacks
     def update_feeds(self, data):
-        for entry in self.poller.parse(data.text()):
+        text = yield data.text()
+        for entry in self.poller.parse(text):
             m = reddit_link.match(entry['link'])
             if m:
                 entry['link'] = "http://redd.it/" + m.group(1)

--- a/mk2/plugins/rss.py
+++ b/mk2/plugins/rss.py
@@ -1,6 +1,6 @@
 import feedparser
 import re
-from twisted.web.client import getPage
+import treq
 
 from mk2.plugins import Plugin
 
@@ -38,11 +38,11 @@ class RSS(Plugin):
             self.repeating_task(self.check_feeds, self.check_interval)
     
     def check_feeds(self, event):
-        d = getPage(self.url)
+        d = treq.get(self.url)
         d.addCallback(self.update_feeds)
     
     def update_feeds(self, data):
-        for entry in self.poller.parse(data):
+        for entry in self.poller.parse(data.text()):
             m = reddit_link.match(entry['link'])
             if m:
                 entry['link'] = "http://redd.it/" + m.group(1)

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -188,6 +188,20 @@ plugin.backup.flush-wait=5
 
 
 ###
+# DISCORD
+# Sends server events to a discord webhook
+plugin.discord.enabled=false
+
+# The webhook url for the channel you want server events to be posted in.
+plugin.discord.webhook_url=
+
+# The name to use as the webhook author
+plugin.discord.webhook_name=mark2
+
+# Server name for the webhook to use
+plugin.discord.server_name=
+
+###
 # IRC
 # relay in-game chat to IRC and visa-versa
 plugin.irc.enabled=false

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -192,14 +192,19 @@ plugin.backup.flush-wait=5
 # Sends server events to a discord webhook
 plugin.discord.enabled=false
 
+# Events to listen to
+plugin.discord.server_started_enabled=true
+plugin.discord.server_starting_enabled=false
+plugin.discord.server_stopped_enabled=true
+plugin.discord.server_stopping_enabled=false
+
 # The webhook url for the channel you want server events to be posted in.
 plugin.discord.webhook_url=
-
 # The name to use as the webhook author
 plugin.discord.webhook_name=mark2
-
 # Server name for the webhook to use
 plugin.discord.server_name=
+
 
 ###
 # IRC

--- a/mk2/servers/__init__.py
+++ b/mk2/servers/__init__.py
@@ -2,7 +2,8 @@ import json
 import sys
 
 from twisted.internet import reactor, defer
-from twisted.web.client import getPage, HTTPClientFactory
+from twisted.web.client import HTTPClientFactory
+import treq
 
 try:
     from twisted.internet import ssl
@@ -36,7 +37,7 @@ class JarProvider:
         self.work()
 
     def get(self, url, callback):
-        d = getPage(str(url))
+        d = treq.get(str(url))
         d.addCallback(callback)
         d.addErrback(self.error)
         return d
@@ -63,7 +64,7 @@ class JenkinsJarProvider(JarProvider):
         self.get('{}job/{}/lastSuccessfulBuild/api/json'.format(self.base, self.project), self.handle_data)
 
     def handle_data(self, data):
-        data = json.loads(data)
+        data = json.loads(data.text())
         url = '{}job/{}/lastSuccessfulBuild/artifact/{}'.format(self.base, self.project, data['artifacts'][0]['relativePath'])
         self.add((self.name, 'Latest'), (None, None), url)
         self.commit()

--- a/mk2/servers/__init__.py
+++ b/mk2/servers/__init__.py
@@ -1,14 +1,8 @@
-import json
+import os
 import sys
 
-from twisted.internet import reactor, defer
-from twisted.web.client import HTTPClientFactory
 import treq
-
-try:
-    from twisted.internet import ssl
-except ImportError:
-    ssl = None
+from twisted.internet import defer
 
 
 class Jar:
@@ -37,9 +31,14 @@ class JarProvider:
         self.work()
 
     def get(self, url, callback):
-        d = treq.get(str(url))
-        d.addCallback(callback)
-        d.addErrback(self.error)
+        d = defer.Deferred()
+        def handle_resp(resp):
+           d = resp.json()
+           d.addCallback(callback)
+           d.addErrback(self.error)
+        resp_defer = treq.get(str(url))
+        resp_defer.addCallback(handle_resp)
+        resp_defer.addErrback(self.error)
         return d
 
     def add(self, *a, **k):
@@ -64,7 +63,6 @@ class JenkinsJarProvider(JarProvider):
         self.get('{}job/{}/lastSuccessfulBuild/api/json'.format(self.base, self.project), self.handle_data)
 
     def handle_data(self, data):
-        data = json.loads(data.text())
         url = '{}job/{}/lastSuccessfulBuild/artifact/{}'.format(self.base, self.project, data['artifacts'][0]['relativePath'])
         self.add((self.name, 'Latest'), (None, None), url)
         self.commit()
@@ -115,7 +113,7 @@ def jar_list():
             o.append((left, right))
 
         for left, right in sorted(o):
-            listing += "  %s | %s\n" % (left.ljust(m), right)
+            listing += "  {} | {}\n".format(left.ljust(m), right)
 
         d_result.callback(listing.rstrip())
 
@@ -126,41 +124,32 @@ def jar_list():
 
 def jar_get(name):
     d_result = defer.Deferred()
+    global did_download
+    did_download = True
 
-    def got_data(factory, data):
-        filename = factory.path.split('/')[-1]
-
-        #parse the Content-Disposition header
-        dis = factory.response_headers.get('content-disposition', None)
-        if dis:
-            dis = dis[0].split(';')
-            if dis[0] == 'attachment':
-                for param in dis[1:]:
-                    key, value = param.strip().split('=')
-                    if key == 'filename':
-                        filename = value.replace("\"", "")
-
-        d_result.callback((filename, data))
+    def err(_):
+        global did_download
+        did_download = False
 
     def got_results(results):
+        global did_download
         for r in results:
             if name == '-'.join(r.name_short):
-                factory = HTTPClientFactory(r.url)
-
-                if factory.scheme == 'https':
-                    if ssl:
-                        reactor.connectSSL(factory.host, factory.port, factory, ssl.ClientContextFactory())
-                    else:
-                        d_result.errback(Exception("{} is not available because this installation does not have SSL support!".format(name)))
+                filename = r.url.split('/')[-1]
+                if os.path.exists(filename):
+                    d_result.errback(Exception("File already exists!"))
                 else:
-                    reactor.connectTCP(factory.host, factory.port, factory)
-
-                factory.deferred.addCallback(lambda d: got_data(factory, d))
-                factory.deferred.addErrback(d_result.errback)
-                return
-
-        d_result.errback(Exception("{} is not available!".format(name)))
+                    print("Downloading file from {} to: {}".format(r.url, filename))
+                    f_out = open(filename, "wb")
+                    resp = treq.get(r.url, unbuffered=True)
+                    resp.addCallback(treq.collect, f_out.write)
+                    did_download = True
+                    resp.addCallback(lambda _: d_result.callback(filename))
+                    resp.addErrback(err)
+                    resp.addBoth(lambda _: f_out.close())
+        if not did_download:
+            d_result.errback(Exception("{} is not available!".format(name)))
 
     d = get_raw()
-    d.addCallbacks(got_results, d_result.errback)
+    d.addCallback(got_results)
     return d_result

--- a/mk2/servers/vanilla.py
+++ b/mk2/servers/vanilla.py
@@ -1,15 +1,34 @@
-import json
+import treq
+from twisted.internet import defer
 
 from . import JarProvider
 
-class Vanilla(JarProvider):
-    base = 'http://s3.amazonaws.com/Minecraft.Download/versions/'
-    def work(self):
-        self.get(self.base + 'versions.json', self.handle_data)
 
+class Vanilla(JarProvider):
+    base = 'https://launchermeta.mojang.com/mc/game/'
+    url = ''
+    def work(self):
+        self.get(self.base + 'version_manifest.json', self.handle_data)
+
+    @defer.inlineCallbacks
     def handle_data(self, data):
-        for k, v in json.loads(data.text())['latest'].iteritems():
-            self.add(('Vanilla', k.title()), (None, None), '{0}{1}/minecraft_server.{1}.jar'.format(self.base, v))
-        self.commit()
+        deferred_list = []
+        def got_json(_json_data, ver_type):
+            self.add(('Vanilla', ver_type.title()), (None, None), _json_data["downloads"]["server"]["url"])
+
+        for k, v in data['latest'].items():
+            for version in data["versions"]:
+                if version["id"].startswith(v) and version["type"] == k:
+                    print("Getting info for: {}-{} with URL: {}".format(v, k, version["url"]))
+                    d = treq.get(version["url"])
+                    resp = yield d
+                    _json = yield resp.json()
+                    got_json(_json, k)
+                    deferred_list.append(d)
+                    break
+        
+        d = defer.DeferredList(deferred_list)
+        d.addCallback(self.commit)
+        d.addErrback(d.errback)
 
 ref = Vanilla

--- a/mk2/servers/vanilla.py
+++ b/mk2/servers/vanilla.py
@@ -8,7 +8,7 @@ class Vanilla(JarProvider):
         self.get(self.base + 'versions.json', self.handle_data)
 
     def handle_data(self, data):
-        for k, v in json.loads(data)['latest'].iteritems():
+        for k, v in json.loads(data.text())['latest'].iteritems():
             self.add(('Vanilla', k.title()), (None, None), '{0}{1}/minecraft_server.{1}.jar'.format(self.base, v))
         self.commit()
 

--- a/mk2/servers/vanilla.py
+++ b/mk2/servers/vanilla.py
@@ -12,6 +12,7 @@ class Vanilla(JarProvider):
 
     @defer.inlineCallbacks
     def handle_data(self, data):
+        print("Getting download info for vanilla versions...")
         deferred_list = []
         def got_json(_json_data, ver_type):
             self.add(('Vanilla', ver_type.title()), (None, None), _json_data["downloads"]["server"]["url"])
@@ -19,7 +20,6 @@ class Vanilla(JarProvider):
         for k, v in data['latest'].items():
             for version in data["versions"]:
                 if version["id"].startswith(v) and version["type"] == k:
-                    print("Getting info for: {}-{} with URL: {}".format(v, k, version["url"]))
                     d = treq.get(version["url"])
                     resp = yield d
                     _json = yield resp.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 feedparser==6.0.8
 psutil==5.8.0
 pyOpenSSL==20.0.1
-Twisted==21.2.0
+Twisted==22.2.0
 urwid==2.1.2
 service_identity==21.1.0
 pyperclip==1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Twisted==21.2.0
 urwid==2.1.2
 service_identity==21.1.0
 pyperclip==1.8.2
+treq==21.5.0

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,10 @@ requirements = ["{0}=={1}".format(*s) for s in [
 ("feedparser",       "6.0.8"),
 ("psutil",           "5.8.0"),
 ("pyOpenSSL",        "20.0.1"),
-("Twisted",          "21.2.0"),
+("Twisted",          "22.2.0"),
 ("urwid",            "2.1.2"),
-("service_identity", "21.1.0")
+("service_identity", "21.1.0"),
+("treq",             "21.5.0")
 
 ] if "MARK2_NO_{0}".format(s[0].upper()) not in os.environ]
 


### PR DESCRIPTION
Added a plugin that will send alerts to a discord webhook

Replaced deprecated twisted `getPage` calls with `treq.get` ones.

Note: `treq.get` returns a [response object](https://treq.readthedocs.io/en/release-21.1.0/_modules/treq/response.html) so all calls that were made with `getPage` also have an [additional step to get the text value](https://treq.readthedocs.io/en/release-21.1.0/api.html#treq.response._Response.text) they needed for parsing. If any were missed, this could break other plugins using this method. I have tried to find them all but would like this to be reviewed by @edk0 before pulling into master as he knows more about the callbacks that are present from these calls than I do.