### PR TITLE
Provide sample Velocity configuration

### DIFF
--- a/samples/velocity/mark2.properties
+++ b/samples/velocity/mark2.properties
@@ -1,0 +1,12 @@
+# Sample Velocity mark2.properties - see https://velocitypowered.com/
+mark2.jar-path=velocity*.jar
+mark2.service.process.done-pattern=Done \(.*\)\!
+mark2.service.process.stop-cmd=end\n
+mark2.regex.join=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}) \\(\\/(?P<ip>.+)\\) has connected
+mark2.regex.quit=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}).* has disconnected(: )?(?P<reason>.*)
+plugin.monitor.crash-unknown-cmd-message=.*command.*does not exist.*
+# requires Velocity Utils plugin: https://forums.velocitypowered.com/t/velocity-utils-useful-commands-like-send-and-find/825
+plugin.shutdown.alert-command=alert %s
+plugin.backup.enabled=false
+plugin.save.enabled=false
+plugin.trigger.enabled=false


### PR DESCRIPTION
Tested:
- detects Done when `mark2 start` performed
- issues `end` when ~stop performed
- sends `alert` when ~stop 1m performed (i.e. 1 minute warning received by player on server behind the proxy)
- lists player in player pane when they join
- removes player from player pane when they quit
- quit message detected whether they quit normally or abnormally (i.e. `(?P<reason>)` is non-empty only for the latter)

see the closed issue #163 