### PR TITLE
Comment out optional alert config to avoid possible error on shutdown

### DIFF
--- a/samples/velocity/mark2.properties
+++ b/samples/velocity/mark2.properties
@@ -6,7 +6,7 @@ mark2.regex.join=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}) \\(\\/(
 mark2.regex.quit=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}).* has disconnected(: )?(?P<reason>.*)
 plugin.monitor.crash-unknown-cmd-message=.*command.*does not exist.*
 # requires Velocity Utils plugin: https://forums.velocitypowered.com/t/velocity-utils-useful-commands-like-send-and-find/825
-plugin.shutdown.alert-command=alert %s
+# plugin.shutdown.alert-command=alert %s
 plugin.backup.enabled=false
 plugin.save.enabled=false
 plugin.trigger.enabled=false


### PR DESCRIPTION
I considered what you said about alert not being needed and agree, it's not strictly necessary. Also, since it requires an optional plugin, if the user didn't install it and they use the sample config, it will trigger an error each time velocity is shutdown via mark2 when it attempts to send the alert with the non-existent command. Therefore, I have commented it out. It's up to the user to uncomment it if they also install the plugin.