### PR TITLE
Comment out optional shutdown alert

### DIFF
--- a/samples/velocity/mark2.properties
+++ b/samples/velocity/mark2.properties
@@ -6,7 +6,7 @@ mark2.regex.join=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}) \\(\\/(
 mark2.regex.quit=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}).* has disconnected(: )?(?P<reason>.*)
 plugin.monitor.crash-unknown-cmd-message=.*command.*does not exist.*
 # requires Velocity Utils plugin: https://forums.velocitypowered.com/t/velocity-utils-useful-commands-like-send-and-find/825
-plugin.shutdown.alert-command=alert %s
+# plugin.shutdown.alert-command=alert %s
 plugin.backup.enabled=false
 plugin.save.enabled=false
 plugin.trigger.enabled=false

--- a/samples/velocity/mark2.properties
+++ b/samples/velocity/mark2.properties
@@ -5,7 +5,8 @@ mark2.service.process.stop-cmd=end\n
 mark2.regex.join=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}) \\(\\/(?P<ip>.+)\\) has connected
 mark2.regex.quit=\\[connected player\\] (?P<username>[A-Za-z0-9_]{1,16}).* has disconnected(: )?(?P<reason>.*)
 plugin.monitor.crash-unknown-cmd-message=.*command.*does not exist.*
-# requires Velocity Utils plugin: https://forums.velocitypowered.com/t/velocity-utils-useful-commands-like-send-and-find/825
+# Alerts require the Velocity Utils plugin (not affiliated with mark2):
+#   https://forums.velocitypowered.com/t/velocity-utils-useful-commands-like-send-and-find/825
 # plugin.shutdown.alert-command=alert %s
 plugin.backup.enabled=false
 plugin.save.enabled=false


### PR DESCRIPTION
The shutdown alert requires an optional plugin to work. Commented out so it won't trigger an error on shutdown if the plugin isn't installed.