### PR TITLE
Fix a bug when trying to cancel an already called or cancelled event

### DIFF
--- a/mk2/plugins/__init__.py
+++ b/mk2/plugins/__init__.py
@@ -249,9 +249,12 @@ class Plugin(metaclass=PluginMetaclass):
         delayed_call = [None]
 
         def cancel(*args):
-            delayed_call[0].cancel()
-            if callbackCancel:
-                callbackCancel(*args)
+            if delayed_call[0].active():
+                delayed_call[0].cancel()
+                if callbackCancel:
+                    callbackCancel(*args)
+            else:
+                self.console("Skipping cancelling of already cancelled or called event")
         
         def action_chain_i(i_name, i_delay, i_action):
             t = reactor.callLater(i_delay, i_action) 

--- a/mk2/plugins/shutdown.py
+++ b/mk2/plugins/shutdown.py
@@ -43,6 +43,7 @@ class Shutdown(Plugin):
     def server_started(self, event):
         self.restart_on_empty = False
         self.cancel_preempt = 0
+        self.cancel.clear()
     
     def warn_restart(self, delay):
         self.send_format(self.alert_command % self.restart_warn_message, delay=delay)


### PR DESCRIPTION
Previously, when a server is restarted the event queue of shutdown events is never cleared. This leads to an exception when trying to cancel a pending restart after a restart has already occurred as the list was never cleared. Now, it correctly checks if events have been called or cancelled before trying to cancel them and the shutdown cancel queue is cleared every time the server is started to ensure it doesn't persist across restarts.

Fixes #152